### PR TITLE
Add readme viewing script

### DIFF
--- a/lab_notebook.sh
+++ b/lab_notebook.sh
@@ -1,0 +1,39 @@
+# Run this script in your log directory, recursively looks for *.readme and 
+# displays them 
+
+# Get readmes
+readmes=$(ls -R -r */*.readme)
+
+# Make a tempfile for concatenating and displaying
+tmpFile=$(tempfile)
+
+# Coloring for easier test to test differentiation in 'less'
+LOGFILEFORMAT="\033[46;1;3;30m"
+
+# Line drawing helper funtion
+draw_line(){
+    for i in $(seq 1 $1); do echo -e -n "-"; done
+}
+
+# Add readmes and headers to tempfile
+for readme in $readmes; do 
+
+    let "readmeLength=${#readme}+6"
+
+    draw_line ${readmeLength} >> $tmpFile
+
+    echo -e "\n${LOGFILEFORMAT}   ${readme}   " >> $tmpFile
+
+    draw_line ${readmeLength} >> $tmpFile
+
+    echo -e "\n" >> $tmpFile
+    cat $readme >> $tmpFile
+    echo -e "\n" >> $tmpFile
+
+done
+
+# Open temp file in less
+less -R $tmpFile
+
+# Delete tempfile (would be deleted automatically, but extra safe)
+rm $tmpFile

--- a/lab_notebook.sh
+++ b/lab_notebook.sh
@@ -1,6 +1,24 @@
 # Run this script in your log directory, recursively looks for *.readme and 
 # displays them 
 
+# Handling '-h' option for help string
+while getopts ":h" option; do
+   case $option in
+      h) # display Help
+         echo "This script creates a lab notebook view of files ending in '.readmes'"
+         echo "Run this script in your logs directory and it will recursively look"
+         echo "through the tree"
+         echo 
+         echo "Syntax: lab_notebook.sh [-h]"
+         echo "options:"
+         echo "    h    Print this help"
+         exit;;
+     \?) # incorrect option
+         echo "Error: Invalid option, use '-h' "
+         exit;;
+   esac
+done
+
 # Get readmes
 readmes=$(ls -R -r */*.readme)
 

--- a/lab_notebook.sh
+++ b/lab_notebook.sh
@@ -20,7 +20,8 @@ while getopts ":h" option; do
 done
 
 # Get readmes
-readmes=$(ls -R -r */*.readme)
+readmes="$(ls -R -r *.readme) "
+readmes+=$(ls -R -r */*.readme)
 
 # Make a tempfile for concatenating and displaying
 tmpFile=$(tempfile)

--- a/lab_notebook.sh
+++ b/lab_notebook.sh
@@ -20,8 +20,8 @@ while getopts ":h" option; do
 done
 
 # Get readmes
-readmes="$(ls -R -r *.readme) "
-readmes+=$(ls -R -r */*.readme)
+readmes="$(ls -R -r *.readme 2>/dev/null) "
+readmes+=$(ls -R -r */*.readme 2>/dev/null)
 
 # Make a tempfile for concatenating and displaying
 tmpFile=$(tempfile)

--- a/lab_notebook.sh
+++ b/lab_notebook.sh
@@ -27,11 +27,11 @@ readmes+=$(ls -R -r */*.readme)
 tmpFile=$(tempfile)
 
 # Coloring for easier test to test differentiation in 'less'
-LOGFILEFORMAT="\033[46;1;3;30m"
+LOGFILEFORMAT="\033[3;33m"
 
 # Line drawing helper funtion
 draw_line(){
-    for i in $(seq 1 $1); do echo -e -n "-"; done
+    for i in $(seq 1 $1); do echo -e -n "${LOGFILEFORMAT}-"; done
 }
 
 # Add readmes and headers to tempfile

--- a/lab_notebook.sh
+++ b/lab_notebook.sh
@@ -1,5 +1,6 @@
 # Run this script in your log directory, recursively looks for *.readme and 
 # displays them 
+# TODO: add directory option, add depth limit/tabbing
 
 # Handling '-h' option for help string
 while getopts ":h" option; do


### PR DESCRIPTION
Add a simple bash that allows the bulk viewing of multiple readmes at once as a simple digital lab notebook.

Nominally, this script is used by calling it from the directory the better_lcm_logger script is using, but can be used in the parent directory of any ".readme" files.

Useful features that might be missing but won't be implemented in this PR
- directory option so it doesn't have to be called locally
- depth limit so that the temp file isn't so large
- save so that the file create is cached/permanent
- formatting options